### PR TITLE
Update caldav.class.php

### DIFF
--- a/core/class/caldav.class.php
+++ b/core/class/caldav.class.php
@@ -110,7 +110,7 @@ class caldav extends eqLogic {
 					foreach ( explode("\n", $data) AS $debug) {
 						//log::add('caldav', 'debug', 'debug : '.$debug);
 						if ( preg_match("!^(.*):(.*)$!", $debug, $regs) ) {
-							if ( strrpos($regs[1], "SUMMARY", -strlen("SUMMARY")) !== false ) {
+							if ( strrpos($regs[1], "SUMMARY", strlen($regs[1])===strlen("SUMMARY")? -strlen("SUMMARY"),strlen($regs[1]) ) !== false ) {
 								log::add('caldav', 'debug', 'Trouve '.chop($regs[2]));
 								array_push($desc_event, chop($regs[2]));
 							}

--- a/core/class/caldav.class.php
+++ b/core/class/caldav.class.php
@@ -110,7 +110,7 @@ class caldav extends eqLogic {
 					foreach ( explode("\n", $data) AS $debug) {
 						//log::add('caldav', 'debug', 'debug : '.$debug);
 						if ( preg_match("!^(.*):(.*)$!", $debug, $regs) ) {
-							if ( strrpos($regs[1], "SUMMARY", strlen($regs[1])===strlen("SUMMARY")? -strlen("SUMMARY"),strlen($regs[1]) ) !== false ) {
+							if ( strrpos($regs[1], "SUMMARY", strlen($regs[1])===strlen("SUMMARY")? -strlen("SUMMARY"):strlen($regs[1]) ) !== false ) {
 								log::add('caldav', 'debug', 'Trouve '.chop($regs[2]));
 								array_push($desc_event, chop($regs[2]));
 							}


### PR DESCRIPTION
évite une entrée dans le log  cron_execution si la longueur de $regs[1] est inférieur à "SUMMARY"